### PR TITLE
add: accept string as value

### DIFF
--- a/src/fit-encode.ts
+++ b/src/fit-encode.ts
@@ -22,7 +22,7 @@ type MessageKeys = keyof FitMessages;
 
 export type FitDevInfo = {
   field_num: number;
-  value: number;
+  value: number | string;
 };
 
 const crc_table = [


### PR DESCRIPTION
In one of our cases, an extra field had to be a string. I added the type string.